### PR TITLE
fix(typescript): build and verify npm package

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -182,6 +182,10 @@ jobs:
           python3 scripts/src/load/merge_data.py -o ./typescript/resources/merged_data.json
           cd typescript
           npm ci
+          npm run build
+      - name: Test packed package
+        working-directory: typescript
+        run: npm run test:package
       - run: |
           cd typescript
           npm publish --provenance --access public

--- a/.github/workflows/typescript.yaml
+++ b/.github/workflows/typescript.yaml
@@ -70,6 +70,9 @@ jobs:
       - name: Run smoke tests against linked package
         working-directory: typescript
         run: npm run test:smoke
+      - name: Test packed package
+        working-directory: typescript
+        run: npm run test:package
 
   lint:
     runs-on: ubuntu-latest

--- a/typescript/README.md
+++ b/typescript/README.md
@@ -1,3 +1,12 @@
+> [!WARNING]
+> Versions `0.9.13` through `2.3.1` of `@licenselynx/licenselynx` were published without the compiled runtime files and are unusable. Upgrade to `2.3.2` or later:
+>
+> ```sh
+> npm install @licenselynx/licenselynx@latest
+> ```
+>
+> The issue is tracked in [#104](https://github.com/licenselynx/licenselynx/issues/104).
+
 # LicenseLynx for TypeScript
 
 In TypeScript, you need to import the ``map`` function from the ``LicenseLynx`` module and use it to map a license name.

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -21,6 +21,7 @@
         "build": "esbuild index.ts --bundle --platform=node --target=node10 --outdir=dist && tsc --emitDeclarationOnly --outDir dist",
         "test": "node tests/run-suite.mjs unit",
         "test:smoke": "node tests/run-suite.mjs smoke",
+        "test:package": "node tests/run-suite.mjs package",
         "lint": "eslint *.ts "
     },
     "repository": {

--- a/typescript/tests/package.test.mjs
+++ b/typescript/tests/package.test.mjs
@@ -1,0 +1,42 @@
+/**
+ * SPDX-FileCopyrightText: Copyright 2025 Siemens AG
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+import { pathToFileURL } from 'node:url';
+
+const root = process.cwd();
+
+test('packed package installs and exposes the library', async () => {
+    const directory = await fs.mkdtemp(path.join(os.tmpdir(), 'licenselynx-package-'));
+
+    try {
+        const filename = execFileSync('npm', ['pack', '--quiet', '--pack-destination', directory], {
+            cwd: root,
+            encoding: 'utf8',
+        }).trim();
+        const tarball = path.join(directory, filename);
+        const packageJson = path.join(directory, 'package.json');
+
+        assert.ok(await fs.stat(path.join(root, 'dist', 'index.js')));
+        assert.ok(await fs.stat(path.join(root, 'dist', 'index.d.ts')));
+        await fs.writeFile(packageJson, JSON.stringify({ private: true }));
+        execFileSync('npm', ['install', '--ignore-scripts', '--no-package-lock', tarball], {
+            cwd: directory,
+            stdio: 'inherit',
+        });
+
+        const modulePath = path.join(directory, 'node_modules', '@licenselynx', 'licenselynx', 'dist', 'index.js');
+        const { map } = await import(pathToFileURL(modulePath).href);
+        const result = await map('0BSD');
+
+        assert.equal(result.id, '0BSD');
+    } finally {
+        await fs.rm(directory, { recursive: true, force: true });
+    }
+});

--- a/typescript/tests/run-suite.mjs
+++ b/typescript/tests/run-suite.mjs
@@ -7,7 +7,7 @@ import fs from 'node:fs/promises';
 import path from 'node:path';
 
 const mode = process.argv[2];
-if (mode !== 'unit' && mode !== 'smoke') {
+if (mode !== 'unit' && mode !== 'smoke' && mode !== 'package') {
     throw new Error(`Unsupported test mode: ${mode}`);
 }
 
@@ -38,7 +38,7 @@ try {
         run('python3', ['../scripts/src/load/merge_data.py', '-o', './resources/merged_data.json']);
         run('npx', ['esbuild', 'index.ts', '--bundle', '--platform=node', '--target=node10', '--outdir=dist']);
         run('npx', ['tsc', '--emitDeclarationOnly', '--outDir', 'dist']);
-        run('node', ['--test', 'tests/smoke.test.mjs']);
+        run('node', ['--test', `tests/${mode}.test.mjs`]);
     }
 } finally {
     await fs.writeFile(resourcesPath, originalResources);


### PR DESCRIPTION
This PR addresses the issue #104.

In this PR I add the build command and also add a smoke test which confirms if the TypeScript lib does include the mappings file before releasing it.