### PR TITLE
chore: minify json lookup map to reduce package size

### DIFF
--- a/scripts/src/load/merge_data.py
+++ b/scripts/src/load/merge_data.py
@@ -80,7 +80,7 @@ def read_org_data(data_dir: str) -> dict:
 
 def write_data(alias_mapping: dict, output_path: str):
     with open(output_path, 'w') as outfile:
-        json.dump(alias_mapping, outfile, indent=4)
+        json.dump(alias_mapping, outfile, separators=(',', ':'))
 
 
 def merge_data_to_paths(data_dir: str, output_path: str):


### PR DESCRIPTION
## Description

Reduces size of all published packages (~`0.5MB`) by minifying the lookup map JSON.